### PR TITLE
Use 'available from' consistently

### DIFF
--- a/journal-of-anatomy.csl
+++ b/journal-of-anatomy.csl
@@ -100,7 +100,7 @@
       </if>
       <else-if variable="URL">
         <group delimiter=". ">
-          <text variable="URL" prefix="Available online: "/>
+          <text variable="URL" prefix="Available from: "/>
           <group delimiter=" ">
             <text term="accessed" text-case="capitalize-first"/>
             <date form="text" variable="accessed"/>


### PR DESCRIPTION
Recent papers in Journal of Anatomy use the text 'Available from: ' before the URL for book chapters and journal articles.